### PR TITLE
Only stat files once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,11 +60,9 @@ fn walk_files(path: &str) -> Result<Vec<(u64, PathBuf)>, io::Error> {
 
     for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
         if entry.file_type().is_file() {
-            let file = File::open(entry.path())?;
-            let file_metadata = file.metadata()?;
-
-            if file_metadata.len() != 0 {
-                files.push((file_metadata.len(), entry.path().to_path_buf()));
+            let file_len = entry.metadata()?.len();
+            if file_len != 0 {
+                files.push((file_len, entry.into_path()));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,5 +122,6 @@ fn blake3_checksum(path: &PathBuf) -> Result<String, io::Error> {
     let mut hasher = Hasher::new();
     let _ = io::copy(&mut f, &mut hasher);
 
-    Ok(format!("{}", hasher.finalize().to_string()))
+    let hash = hasher.finalize().to_string();
+    Ok(hash)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 // Std
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fs::File;
 use std::io;
@@ -71,8 +71,8 @@ fn walk_files(path: &str) -> Result<Vec<(u64, PathBuf)>, io::Error> {
 
 // group_files_by_size group all files by file size. Using a
 // vector with size and path.
-fn group_files_by_size(files: Vec<(u64, PathBuf)>) -> HashMap<u64, Vec<PathBuf>> {
-    let mut groups: HashMap<u64, Vec<PathBuf>> = HashMap::new();
+fn group_files_by_size(files: Vec<(u64, PathBuf)>) -> BTreeMap<u64, Vec<PathBuf>> {
+    let mut groups: BTreeMap<u64, Vec<PathBuf>> = BTreeMap::new();
 
     for (size, path) in files {
         groups.entry(size).or_default().push(path);
@@ -83,7 +83,7 @@ fn group_files_by_size(files: Vec<(u64, PathBuf)>) -> HashMap<u64, Vec<PathBuf>>
 // group_files_by_checksum group all files by checksum. Using blake3 to calculate a
 // checksum for the files.
 fn group_files_by_checksum(
-    files: HashMap<u64, Vec<PathBuf>>,
+    files: BTreeMap<u64, Vec<PathBuf>>,
 ) -> Result<HashMap<String, Vec<PathBuf>>, io::Error> {
     let mut groups: HashMap<String, Vec<PathBuf>> = HashMap::new();
 


### PR DESCRIPTION
This revamps a few parts to not call for metadata on files as much, reducing the amount of syscalls per execution
